### PR TITLE
New primitives

### DIFF
--- a/ExampleCode/BasicGrammar.skiy
+++ b/ExampleCode/BasicGrammar.skiy
@@ -1,7 +1,7 @@
 //An example of the absolute minimum required for a Skiylia pre-release
 
 //reserved words:
-true, false, null, var, if, else, elif, while, for, do, Where , When, def, class, super, self, print, str, string, int, integer, flt, float
+true, false, null, var, if, else, elif, while, for, do, Where , When, def, class, super, self, print, str, string, int, integer, float
 
 //required symbols:
 '(', ')', ':', ',', '.', '-', '+', '*', '/', '//', '>', '<', '=', '!', '"', '&', '|',

--- a/ExampleCode/BasicGrammar.skiy
+++ b/ExampleCode/BasicGrammar.skiy
@@ -79,7 +79,7 @@ while a>5:
   a = a-1
 
 //for loop
-for (increment variable) (Where | When) (condition) do (increment operation):
+for (increment variable) ("where" | "when") (condition) "do" (increment operation):
   action-during-loop
 
 ie:

--- a/ExampleCode/ExtendedBakusNaurForm.txt
+++ b/ExampleCode/ExtendedBakusNaurForm.txt
@@ -59,11 +59,11 @@ expression        > assignment
 assignment        > (call ".")? Identifier "=" assignment | logicalOr
 
 //Logical or has the highest precedence (and is computed last)
-logicalOr         > logicalXor ( "|" logicalXor )*
+logicalOr         > logicalXor ( ( "|" | "or" ) logicalXor )*
 
-logicalXor        > logicalAnd ( "^" logicalAnd )*
+logicalXor        > logicalAnd ( ( "^" | "xor" ) logicalAnd )*
 
-logicalAnd        > equality ( ( "&" ) equality )*
+logicalAnd        > equality ( ( ( "&" | "and" ) ) equality )*
 
 equality          > comparison ( ( "!=" | "==" ) comparison )*
 

--- a/ExampleCode/Fibonacci.skiy
+++ b/ExampleCode/Fibonacci.skiy
@@ -1,4 +1,6 @@
-//calculate the fibonaci sequence using functional calls
+///calculate the fibonaci sequence using functional calls
+  notice how I am now using multi-line comments
+  very intriguing, don't you think?///
 def fib(n):
   if n>1:
     return fib(n-1) + fib(n-2)

--- a/PySkiylia/Interpreter.py
+++ b/PySkiylia/Interpreter.py
@@ -120,8 +120,12 @@ class Interpreter(misc, Evaluator):
             token = e.args[0][0]
             #and message
             message = e.args[0][1]
+            #default error type, if none given
+            where = "Runtime"
+            if len(e.args[0])==2:
+                where = e.args[0][2]
             #and raise an error
-            self.skiylia.error(token.line, token.char, message, "Runtime")
+            self.skiylia.error(token.line, token.char, message, where)
 
     #define a way to assign variables abstractly
     def AssignExpr(self, expr):

--- a/PySkiylia/Interpreter.py
+++ b/PySkiylia/Interpreter.py
@@ -178,6 +178,12 @@ class Interpreter(misc, Evaluator):
             if float(right) == 0:
                 raise RuntimeError([expr.operator,"division by zero"])
             return float(left) / float(right)
+        elif optype == "StarStar":
+            self.checkNumber(expr.operator, left, right)
+            #divide if given
+            if float(right) == 0:
+                raise RuntimeError([expr.operator,"division by zero"])
+            return float(left) ** float(right)
         elif optype == "Star":
             #check if one (and only one) is a number, so we can repeat substrings
             xornum = self.xorNumber(left, right)

--- a/PySkiylia/Interpreter.py
+++ b/PySkiylia/Interpreter.py
@@ -87,6 +87,7 @@ class Interpreter(misc, Evaluator):
         #define the maximum number of allowed arguments in a function call
         self.arglimit = arglimit
         #and add our primitives to the global scope
+        self.primitives = []
         self.fetchprimitives()
 
     #define the primitives
@@ -103,6 +104,7 @@ class Interpreter(misc, Evaluator):
                 if primitive.callname:
                     callname=primitive.callname
                 #add them to the global scope
+                self.primitives.append(callname)
                 self.globals.define(callname, primitive())
 
     #define the interpreter function
@@ -229,6 +231,8 @@ class Interpreter(misc, Evaluator):
             #raise an error if it was different
             raise RuntimeError([expr.parenthesis, "Expected {} argument{} but got {}.".format(arglim, "s"*(arglim!=1), len(args))])
         #return and call the callable
+        if expr.callee.name.lexeme in self.primitives:
+            return callee.call(self, args, expr.callee.name)
         return callee.call(self, args)
 
     #define how our interpreter handles classes

--- a/PySkiylia/Lexer.py
+++ b/PySkiylia/Lexer.py
@@ -99,9 +99,16 @@ class Lexer:
         elif c == "/":
             #as division and comments use the same character, check if the next is a comment
             if self.match("/"):
-                #keep advancing until we find a newline
-                while not self.match("\n", peek=True):
-                    self.advance()
+                #as multi-line comments are ///, whereas a single line is //, we need to check for that too!
+                if self.match("/"):
+                    #keep advancing until we find the tripple comment escape
+                    self.advance(3)
+                    while self.peeklast(3) != "///":
+                        self.advance()
+                else:
+                    #keep advancing until we find a newline
+                    while not self.match("\n", peek=True) and not self.atEnd():
+                        self.advance()
             else:
                 return self.addToken("Slash")
         elif c == ">":
@@ -265,6 +272,10 @@ class Lexer:
         #otherwise return the character
         return self.source[self.current+1]
 
+    #return the previous character(s) without advancing
+    def peeklast(self, chars=1):
+        return self.source[self.current-chars:self.current]
+
     #return the previous token
     def previousToken(self):
         #get the last token and test
@@ -279,9 +290,9 @@ class Lexer:
         return self.previousToken().type == type
 
     #advance through the source code and return the character
-    def advance(self):
+    def advance(self, chars=1):
         #increment the Lexer position
-        self.current += 1
+        self.current += chars
         #return the character we just skiped over
         return self.source[self.current-1]
 

--- a/PySkiylia/Lexer.py
+++ b/PySkiylia/Lexer.py
@@ -95,6 +95,8 @@ class Lexer:
         elif c == "+":
             return self.addToken("Plus")
         elif c == "*":
+            if self.match("*"):
+                return self.addToken("StarStar")
             return self.addToken("Star")
         elif c == "/":
             #as division and comments use the same character, check if the next is a comment

--- a/PySkiylia/Parser.py
+++ b/PySkiylia/Parser.py
@@ -97,10 +97,12 @@ class Parser:
             return self.returnstatement()
         #check if the token matches a primitive, and shortcut to the call logic
         elif self.peek().lexeme in self.primitives:
+            ptoken = self.peek()
             #fetch the primitive code
             callfunc = self.call()
             #make sure the primitive closes
             self.consume("Unbounded function.", "End")
+            callfunc.token = ptoken
             #and return it
             return callfunc
         #else return an expression statement

--- a/PySkiylia/Parser.py
+++ b/PySkiylia/Parser.py
@@ -451,7 +451,7 @@ class Parser:
         #fetch the first factor
         expr = self.unary()
         #loop through all comparison posibilities
-        while self.match("Star", "Slash"):
+        while self.match("Star", "Slash", "StarStar"):
             #fetch the operator
             operator = self.previous()
             #fetch the unary associated
@@ -571,7 +571,7 @@ class Parser:
         elif self.match("Plus"):
             a = self.term
         #and finally a factor
-        elif self.match("Slash", "Star"):
+        elif self.match("Slash", "Star", "StarStar"):
             a = self.factor
         #otherwise, return false, as we didn't encounter an erroneous left hand operation
         else:

--- a/PySkiylia/Primitives.py
+++ b/PySkiylia/Primitives.py
@@ -54,9 +54,14 @@ class skiyliaclock(SkiyliaCallable):
 #sqrt
 class skiyliasqrt(SkiyliaCallable):
     string = "primitive function"
+    arity=1
     callname = "sqrt"
     def call(self, interpreter, arguments, token):
-        return math.sqrt(arguments[0])
+        n = arguments[0]
+        try:
+            return math.sqrt(n)
+        except Exception as e:
+            raise RuntimeError([token, str(e), type(e).__name__])
 
 #string conversion
 class skiyliastring(SkiyliaCallable):
@@ -77,11 +82,11 @@ class skiyliainteger(SkiyliaCallable):
     arity = 1
     callname = "integer"
     def call(self, interpreter, arguments, token):
-        num = arguments[0]
+        n = arguments[0]
         try:
-            return float(int(float(num)))         #skiylia represents all numbers as floats
+            return float(int(float(n)))         #skiylia represents all numbers as floats
         except Exception as e:
-            raise RuntimeError([token, "Cannot convert '{}' to integer.".format(num)])
+            raise RuntimeError([token, str(e), type(e).__name__])
 
 #shorthand for integer
 class skiyliaint(skiyliainteger, SkiyliaCallable):
@@ -94,8 +99,80 @@ class skiyliafloat(SkiyliaCallable):
     arity = 1
     callname = "float"
     def call(self, interpreter, arguments, token):
-        num = arguments[0]
+        n = arguments[0]
         try:
-            return float(num)
+            return float(n)
         except Exception as e:
-            raise RuntimeError([token, "Cannot convert '{}' to float.".format(num)])
+            raise RuntimeError([token, str(e), type(e).__name__])
+
+#absolute value return
+class skiyliaabsolute(SkiyliaCallable):
+    string = "primitive function"
+    arity = 1
+    callname = "abs"
+    def call(self, interpreter, arguments, token):
+        n = arguments[0]
+        try:
+            return abs(float(n))
+        except Exception as e:
+            raise RuntimeError([token, str(e), type(e).__name__])
+
+#power
+class skiyliapow(SkiyliaCallable):
+    string = "primitive function"
+    arity = 2
+    callname = "pow"
+    def call(self, interpreter, arguments, token):
+        n, m = arguments
+        try:
+            return float(n) ** float(m)
+        except Exception as e:
+            raise RuntimeError([token, str(e), type(e).__name__])
+
+#modulo
+class skiyliamod(SkiyliaCallable):
+    string = "primitive function"
+    arity = 2
+    callname = "mod"
+    def call(self, interpreter, arguments, token):
+        n, m = arguments
+        try:
+            return float(n) % float(m)
+        except Exception as e:
+            raise RuntimeError([token, str(e), type(e).__name__])
+
+#floor
+class skiyliafloor(SkiyliaCallable):
+    string = "primitive function"
+    arity = 1
+    callname = "floor"
+    def call(self, interpreter, arguments, token):
+        n = arguments[0]
+        try:
+            return float(round(float(n) - .5))
+        except Exception as e:
+            raise RuntimeError([token, str(e), type(e).__name__])
+
+#ceil
+class skiyliaceil(SkiyliaCallable):
+    string = "primitive function"
+    arity = 1
+    callname = "ceil"
+    def call(self, interpreter, arguments, token):
+        n = arguments[0]
+        try:
+            return float(round(float(n) + .5))
+        except Exception as e:
+            raise RuntimeError([token, str(e), type(e).__name__])
+
+#ceil
+class skiyliaround(SkiyliaCallable):
+    string = "primitive function"
+    arity = "1,2"
+    callname = "round"
+    def call(self, interpreter, arguments, token):
+        a, b = (arguments+[0])[:2]
+        try:
+            return float(round(float(a), int(b)))
+        except Exception as e:
+            raise RuntimeError([token, str(e), type(e).__name__])

--- a/PySkiylia/Primitives.py
+++ b/PySkiylia/Primitives.py
@@ -98,4 +98,4 @@ class skiyliafloat(SkiyliaCallable):
         try:
             return float(num)
         except Exception as e:
-            raise RuntimeError([token, "Cannot convert '{}' to integer.".format(num)])
+            raise RuntimeError([token, "Cannot convert '{}' to float.".format(num)])

--- a/PySkiylia/Primitives.py
+++ b/PySkiylia/Primitives.py
@@ -30,12 +30,14 @@ def stringify(obj):
     #return the string of the object
     return str(obj)
 
+class primitivefunc(SkiyliaCallable):
+    string = "primitive function"
+
 #print function
-class skiyliaprint(SkiyliaCallable):
+class skiyliaprint(primitivefunc):
     #define the functional input
     #print can take any number of arguments, but needs at least zero
     arity = "0,*"
-    string = "primitive function"
     callname = "print"
     #overwrite the call
     def call(self, interpreter, arguments):
@@ -43,19 +45,52 @@ class skiyliaprint(SkiyliaCallable):
         return None
 
 #clock
-class skiyliaclock(SkiyliaCallable):
+class skiyliaclock(primitivefunc):
     #define the function stuff
-    arity = 0
-    string = "primitive function"
     callname = "clock"
     #and overwite the call
     def call(self, interpreter, arguments):
         return time.time()
 
 #sqrt
-class skiyliasqrt(SkiyliaCallable):
-    arity = 1
-    string = "primitive function"
+class skiyliasqrt(primitivefunc):
     callname = "sqrt"
     def call(self, interpreter, arguments):
         return math.sqrt(arguments[0])
+
+#string conversion
+class skiyliastring(primitivefunc):
+    arity = "0,*"
+    callname = "string"
+    def call(self, interpreter, arguments):
+        return " ".join(str(x) for x in a)
+
+#string shorthand
+class skiyliastr(skiyliastring):
+    callname = "str"
+
+#integer conversion
+class skiyliainteger(primitivefunc):
+    arity = 1
+    callname = "integer"
+    def call(self, interpreter, arguments):
+        num = arguments[0]
+        try:
+            return float(int(float(num)))         #skiylia represents all numbers as floats
+        except:
+            raise RuntimeError("Cannot convert '{}' to integer.".format(num))
+
+#shorthand for integer
+class skiyliaint(skiyliainteger):
+    callname = "int"
+
+#float conversion
+class skiyliafloat(primitivefunc):
+    arity = 1
+    callname = "float"
+    def call(self, interpreter, arguments):
+        num = arguments[0]
+        try:
+            return float(num)
+        except:
+            raise RuntimeError("Cannot convert '{}' to integer.".format(num))

--- a/PySkiylia/Primitives.py
+++ b/PySkiylia/Primitives.py
@@ -30,67 +30,72 @@ def stringify(obj):
     #return the string of the object
     return str(obj)
 
-class primitivefunc(SkiyliaCallable):
-    string = "primitive function"
-
 #print function
-class skiyliaprint(primitivefunc):
+class skiyliaprint(SkiyliaCallable):
+    string = "primitive function"
     #define the functional input
     #print can take any number of arguments, but needs at least zero
     arity = "0,*"
     callname = "print"
     #overwrite the call
-    def call(self, interpreter, arguments):
+    def call(self, interpreter, arguments, token):
         print(*map(stringify, arguments))
         return None
 
 #clock
-class skiyliaclock(primitivefunc):
+class skiyliaclock(SkiyliaCallable):
+    string = "primitive function"
     #define the function stuff
     callname = "clock"
     #and overwite the call
-    def call(self, interpreter, arguments):
+    def call(self, interpreter, arguments, token):
         return time.time()
 
 #sqrt
-class skiyliasqrt(primitivefunc):
+class skiyliasqrt(SkiyliaCallable):
+    string = "primitive function"
     callname = "sqrt"
-    def call(self, interpreter, arguments):
+    def call(self, interpreter, arguments, token):
         return math.sqrt(arguments[0])
 
 #string conversion
-class skiyliastring(primitivefunc):
+class skiyliastring(SkiyliaCallable):
+    string = "primitive function"
     arity = "0,*"
     callname = "string"
-    def call(self, interpreter, arguments):
-        return " ".join(str(x) for x in a)
+    def call(self, interpreter, arguments, token):
+        return " ".join([stringify(x) for x in arguments])
 
 #string shorthand
-class skiyliastr(skiyliastring):
+class skiyliastr(skiyliastring, SkiyliaCallable):
+    string = "primitive function"
     callname = "str"
 
 #integer conversion
-class skiyliainteger(primitivefunc):
+class skiyliainteger(SkiyliaCallable):
+    string = "primitive function"
     arity = 1
     callname = "integer"
-    def call(self, interpreter, arguments):
+    def call(self, interpreter, arguments, token):
         num = arguments[0]
         try:
             return float(int(float(num)))         #skiylia represents all numbers as floats
-        except:
-            raise RuntimeError("Cannot convert '{}' to integer.".format(num))
+        except Exception as e:
+            raise RuntimeError([token, "Cannot convert '{}' to integer.".format(num)])
 
 #shorthand for integer
-class skiyliaint(skiyliainteger):
+class skiyliaint(skiyliainteger, SkiyliaCallable):
+    string = "primitive function"
     callname = "int"
 
 #float conversion
-class skiyliafloat(primitivefunc):
+class skiyliafloat(SkiyliaCallable):
+    string = "primitive function"
     arity = 1
     callname = "float"
-    def call(self, interpreter, arguments):
+    def call(self, interpreter, arguments, token):
         num = arguments[0]
         try:
             return float(num)
-        except:
-            raise RuntimeError("Cannot convert '{}' to integer.".format(num))
+        except Exception as e:
+            raise RuntimeError([token, "Cannot convert '{}' to integer.".format(num)])

--- a/PySkiylia/PySkiylia.py
+++ b/PySkiylia/PySkiylia.py
@@ -69,6 +69,13 @@ class Skiylia:
             #check they did not ask to quit
             if line.lower() in ["quit", "exit"]:
                 break
+            #make sure the user hasn't given a function (or otherwise) that requires multi-line
+            if line.replace(" ", "")[-1] == ":":
+                while True:
+                    nextinput = input(" |")
+                    line += "\n"+nextinput
+                    if not nextinput:
+                        break
             #else, try to run the code they provided
             self.run(line)
             #reset the error flag, if it was set

--- a/PySkiylia/PySkiylia.py
+++ b/PySkiylia/PySkiylia.py
@@ -14,7 +14,7 @@ from ASTPrinter import ASTPrinter
 class Skiylia:
     #set the default values here
     haderror = False
-    version = "v0.6.0"
+    version = "v0.6.1"
     debug = True
     #run this at initialisation
     def __init__(self, args=""):

--- a/PySkiylia/SkiyliaCallable.py
+++ b/PySkiylia/SkiyliaCallable.py
@@ -21,7 +21,7 @@ class SkiyliaCallable:
         return "<{}>".format(self.string)
 
     #define the way of calling the function
-    def call(self, interpreter, arguments):
+    def call(self, interpreter, arguments, token):
         #we're given the interpreter state in case we need it's memory
         pass
 

--- a/PySkiylia/Tokens.py
+++ b/PySkiylia/Tokens.py
@@ -2,9 +2,9 @@
 """Stores token definitions, may end up moving this elsewhere"""
 
 tokens = [#single character tokens
-            "LeftParenthesis", "RightParenthesis", "Colon", "Comma", "Dot", "Minus", "Plus", "Star", "Slash", "Greater", "Less",
+            "LeftParenthesis", "RightParenthesis", "Colon", "Comma", "Dot", "Minus", "Plus", "Star", "Slash", "Greater", "Less", "And", "Or", "Xor"
             #single or double character Tokens
-            "NotEqual", "Not", "EqualEqual", "Equal", "And", "Xor", "Or",
+            "NotEqual", "Not", "EqualEqual", "Equal",
             #Literal tokens
             "String", "Number", "Identifier",
             #keyword tokens
@@ -13,10 +13,10 @@ tokens = [#single character tokens
             "EOF", "End"]
 
 #a dictionary mapping keywords to their equivalent tokens
-keywords = {"class":"Class", "def":"Def", "do":"Do", "elif":"Elif", "else":"Else",
-            "false":"False", "for":"For", "if":"If", "null":"Null",
+keywords = {"and":"And", "class":"Class", "def":"Def", "do":"Do", "elif":"Elif", "else":"Else",
+            "false":"False", "for":"For", "if":"If", "not":"Not", "null":"Null", "or":"Or",
             "return":"Return", "self":"Self", "super":"Super", "true":"True", "var":"Var",
-            "when":"Where", "where":"Where", "while":"While",}
+            "when":"Where", "where":"Where", "while":"While", "xor":"Xor",}
 
 class Token:
     def __init__(self, type, lexeme, literal, line, char, indent):

--- a/PySkiylia/Tokens.py
+++ b/PySkiylia/Tokens.py
@@ -2,9 +2,9 @@
 """Stores token definitions, may end up moving this elsewhere"""
 
 tokens = [#single character tokens
-            "LeftParenthesis", "RightParenthesis", "Colon", "Comma", "Dot", "Minus", "Plus", "Star", "Slash", "Greater", "Less", "And", "Or", "Xor"
+            "LeftParenthesis", "RightParenthesis", "Colon", "Comma", "Dot", "Minus", "Plus", "Slash", "Greater", "Less", "And", "Or", "Xor"
             #single or double character Tokens
-            "NotEqual", "Not", "EqualEqual", "Equal",
+            "NotEqual", "Not", "EqualEqual", "Equal", "Star", "StarStar"
             #Literal tokens
             "String", "Number", "Identifier",
             #keyword tokens


### PR DESCRIPTION
new primitives have been included: 'str', 'float', 'int', 'ceil', 'floor', 'mod', 'pow', 'round', 'abs'.
better error handling for primitives in general.
users can now type the names of logicals ('and', 'or', 'not', 'xor') as well as using symbols ('&', '|', '!', '^').
added '**' as shorthand for exponentiation.
included multi-line comments (accessible with '\\\' rather than the single-line '\\')