### PR TITLE
More comparisons

### DIFF
--- a/ExampleCode/Grammar/ExtendedBakusNaurForm.txt
+++ b/ExampleCode/Grammar/ExtendedBakusNaurForm.txt
@@ -69,7 +69,7 @@ logicalXor        > logicalAnd ( ( "^" | "xor" ) logicalAnd )*
 
 logicalAnd        > equality ( ( ( "&" | "and" ) ) equality )*
 
-equality          > comparison ( ( "!=" | "==" | "!==" | "===" ) comparison )*
+equality          > comparison ( ( "!=" | "==" | "!==" | "===" | "!~~" | "~~~" ) comparison )*
 
 //Then comparisons
 comparison        > term ( ( ">" | ">=" | "<" | "<=" ) term )*

--- a/ExampleCode/Grammar/ExtendedBakusNaurForm.txt
+++ b/ExampleCode/Grammar/ExtendedBakusNaurForm.txt
@@ -69,10 +69,10 @@ logicalXor        > logicalAnd ( ( "^" | "xor" ) logicalAnd )*
 
 logicalAnd        > equality ( ( ( "&" | "and" ) ) equality )*
 
-equality          > comparison ( ( "!=" | "==" ) comparison )*
+equality          > comparison ( ( "!=" | "==" | "!==" | "===" ) comparison )*
 
 //Then comparisons
-comparison        > term ( ( ">" | "<" ) term )*
+comparison        > term ( ( ">" | ">=" | "<" | "<=" ) term )*
 
 //Then terms
 term              > factor ( ( "-" | "+" ) factor )*

--- a/ExampleCode/Grammar/FullGrammar.skiy
+++ b/ExampleCode/Grammar/FullGrammar.skiy
@@ -44,9 +44,13 @@ a++         //postfix addition
 
 //Comparisons and equalities
 a < b       //less than
+a <= b      //less than or equal to
 a > b       //greater than
+a >= b      //greater than or equal to
 a == b      //equal to
+a === b     //exactly equal to (same type, as well as same value)   <- "3.0" == 3 gives true, "3.0" === 3 gives false, as "3.0" is a string
 a != b      //not equal to
+a !== b     //not exactly equal to
 
 //Logical operators
 -a          //negates the value of a  -6 -> 6, "-6" causes an error (at the present)

--- a/ExampleCode/Grammar/FullGrammar.skiy
+++ b/ExampleCode/Grammar/FullGrammar.skiy
@@ -48,9 +48,11 @@ a <= b      //less than or equal to
 a > b       //greater than
 a >= b      //greater than or equal to
 a == b      //equal to
-a === b     //exactly equal to (same type, as well as same value)   <- "3.0" == 3 gives true, "3.0" === 3 gives false, as "3.0" is a string
+a === b     //strictly equal to (same type, as well as same value)   <- "3.0" == 3 gives true, "3.0" === 3 gives false, as "3.0" is a string
+a ~~~ b     //Fuzzily equal to (same type, don't care about value)   <- "3.0" == 3 gives false, "3.0" === 3 gives false, none of them have the same type
 a != b      //not equal to
-a !== b     //not exactly equal to
+a !== b     //not strictly equal to
+a !~~ b     //not fuzzily equal to
 
 //Logical operators
 -a          //negates the value of a  -6 -> 6, "-6" causes an error (at the present)

--- a/ExampleCode/Logicals/Equality.skiy
+++ b/ExampleCode/Logicals/Equality.skiy
@@ -6,9 +6,9 @@ print(false == false)       //true
 
 print(true == 1)            //true
 print(false == 0)           //true
-print(true == "true")       //false
-print(false == "false")     //false
-print(false == "")          //false
+print(true == "true")       //true
+print(false == "false")     //false   <- nonempty strings evaluate as true
+print(false == "")          //true   <- empty strings evaluate as false
 
 print(true != true)         //false
 print(true != false)        //true
@@ -17,6 +17,6 @@ print(false != false)       //false
 
 print(true != 1)            //false
 print(false != 0)           //false
-print(true != "true")       //true
+print(true != "true")       //false   <- nonempty strings evaluate as true
 print(false != "false")     //true
-print(false != "")          //true
+print(false != "")          //false   <- empty strings evaluate as false

--- a/ExampleCode/Logicals/FuzzyEquality.skiy
+++ b/ExampleCode/Logicals/FuzzyEquality.skiy
@@ -1,0 +1,52 @@
+//test the strict equality operator
+print("comparisons")
+print(true ~~~ true)         //true
+print(true ~~~ false)        //true
+print(false ~~~ true)        //true
+print(false ~~~ false)       //true
+
+print("non-boolean")
+print(true ~~~ 1)            //true       <- '1' is an implicit true
+print(false ~~~ 0)           //true       <- '0' is an implicit false
+print(true ~~~ "true")       //false
+print(false ~~~ "false")     //false      <- none of these have the same type
+print(false ~~~ "")          //false
+
+print("strings, integers, and float")
+print(1 ~~~ 1)               //true       <- have to be both same type and same value to show as false
+print(1 ~~~ 1.0)             //false      <- int and float are different types
+print(1 ~~~ "1")             //false
+print(1 ~~~ "1.0")           //false
+print(1 ~~~ true)            //true       <- '1' (as an integer) is an implicit true
+print(1.0 ~~~ "1")           //false      <- if they're different type, even if same value, then true
+print(1.0 ~~~ "1.0")         //false
+print(1.0 ~~~ true)          //false      <- however, '1.0' (as a float) is not an implicit true
+print("1" ~~~ "1.0")         //true       <- both are strings
+print("1" ~~~ true)          //false
+print("1.0" ~~~ true)        //false
+
+print("comparisons")
+print(true !~~ true)         //false
+print(true !~~ false)        //false
+print(false !~~ true)        //false
+print(false !~~ false)       //false
+
+print("non-boolean")
+print(true !~~ 1)            //false
+print(false !~~ 0)           //false
+print(true !~~ "true")       //true
+print(false !~~ "false")     //true       <- none of these have the same type
+print(false !~~ "")          //true
+
+print("strings, integers, and float")
+print(1 !~~ 1)               //false      <- have to be both same type and same value to show as false
+print(1 !~~ 1.0)             //true
+print(1 !~~ "1")             //true
+print(1 !~~ "1.0")           //true
+print(1 !~~ true)            //false      <- '1' (as an integer) is an explicit true
+print(1.0 !~~ "1")           //true
+print(1.0 !~~ "1.0")         //true
+print(1.0 !~~ true)          //true       <- '1.0' (as a float) is not an explicit true
+print("1" !~~ "1.0")         //false      <- both are strings
+print("1" !~~ true)          //true
+print("1.0" !~~ true)        //true

--- a/ExampleCode/Logicals/StrictEquality.skiy
+++ b/ExampleCode/Logicals/StrictEquality.skiy
@@ -1,0 +1,52 @@
+//test the strict equality operator
+print("comparisons")
+print(true === true)         //true
+print(true === false)        //false
+print(false === true)        //false
+print(false === false)       //true
+
+print("non-boolean")
+print(true === 1)            //true     <- '1' is an implicit true
+print(false === 0)           //true     <- '0' is an implicit false
+print(true === "true")       //false
+print(false === "false")     //false    <- none of these have the same type as a boolean
+print(false === "")          //false
+
+print("strings, integers, and float")
+print(1 === 1)               //true     <- have to be both same type and same value to show as false
+print(1 === 1.0)             //false
+print(1 === "1")             //false
+print(1 === "1.0")           //false
+print(1 === true)            //false
+print(1.0 === "1")           //false     <- if they're different type, even if same value, then true
+print(1.0 === "1.0")         //false
+print(1.0 === true)          //false
+print("1" === "1.0")         //false
+print("1" === true)          //false
+print("1.0" === true)        //false
+
+print("comparisons")
+print(true !== true)         //false
+print(true !== false)        //true
+print(false !== true)        //true
+print(false !== false)       //false
+
+print("non-boolean")
+print(true !== 1)            //false
+print(false !== 0)           //false
+print(true !== "true")       //true
+print(false !== "false")     //true     <- none of these have the same type as a boolean
+print(false !== "")          //true
+
+print("strings, integers, and float")
+print(1 !== 1)               //false    <- have to be both same type and same value to show as false
+print(1 !== 1.0)             //true
+print(1 !== "1")             //true
+print(1 !== "1.0")           //true
+print(1 !== true)            //true     <- if they're different type, even if same value, then true
+print(1.0 !== "1")           //true
+print(1.0 !== "1.0")         //true
+print(1.0 !== true)          //true
+print("1" !== "1.0")         //true
+print("1" !== true)          //true
+print("1.0" !== true)        //true

--- a/ExampleCode/Logicals/comparison.skiy
+++ b/ExampleCode/Logicals/comparison.skiy
@@ -1,0 +1,33 @@
+//comparison operators
+
+print("greater")
+print(true > 0)               //true
+print(1 > 0)                  //true
+print("1" > 0)                //true
+print(true > 1)               //false
+print(1 > 1)                  //false
+print("1" > 1)                //false
+
+print("greater or equal")
+print(true >= 0)              //true
+print(1 >= 0)                 //true
+print("1" >= 0)               //true
+print(true >= 1)              //true
+print(1 >= 1)                 //true
+print("1" >= 1)               //true
+
+print("less")
+print(true < 0)               //false
+print(1 < 0)                  //false
+print("1" < 0)                //false
+print(true < 1)               //false
+print(1 < 1)                  //false
+print("1" < 1)                //false
+
+print("less or equal")
+print(true <= 0)              //false
+print(1 <= 0)                 //false
+print("1" <= 0)               //false
+print(true <= 1)              //true
+print(1 <= 1)                 //true
+print("1" <= 1)               //true

--- a/PySkiylia/Interpreter.py
+++ b/PySkiylia/Interpreter.py
@@ -70,8 +70,7 @@ class misc:
         if a==None:
             return False
         try:
-            b = type(a)(b)
-            return a==b
+            return float(a) == float(b)
         except:
             #else return the python equality
             return a==b
@@ -164,39 +163,45 @@ class Interpreter(misc, Evaluator):
             self.checkNumber(expr.operator, left, right)
             #greater comparison
             return float(left) > float(right)
-        if optype == "EGreater":
+        elif optype == "EGreater":
             self.checkNumber(expr.operator, left, right)
             #greater or equal comparison
             return float(left) >= float(right)
-        if optype == "Less":
+        elif optype == "Less":
             self.checkNumber(expr.operator, left, right)
             #less comparison
             return float(left) < float(right)
-        if optype == "ELess":
+        elif optype == "ELess":
             self.checkNumber(expr.operator, left, right)
             #less of equal comparison
             return float(left) <= float(right)
-        if optype == "NEqual":
+        elif optype == "NEqual":
             #inequality comparison
             return not self.isEqual(left, right)
-        if optype == "EEqual":
+        elif optype == "EEqual":
             #equality comparison
             return self.isEqual(left, right)
-        if optype == "NEEqual":
+        elif optype == "NEEqual":
             #strictly not equal
             if isinstance(left, type(right)) and self.isEqual(left, right):
                 #if they're the same type, and are equal, return false
                 return False
             #true in any other case
             return True
-        if optype == "EEEqual":
+        elif optype == "EEEqual":
             #strictly equal
             if isinstance(left, type(right)):
                 #if they're the same type, check if they are equal
                 return self.isEqual(left, right)
             #false if they have different types
             return False
-        if optype == "Minus":
+        elif optype == "NFuzequal":
+            #Fuzzily equal only checks for type equality
+            return not isinstance(left, type(right))
+        elif optype == "Fuzequal":
+            #Fuzzily equal only checks for type equality
+            return isinstance(left, type(right))
+        elif optype == "Minus":
             self.checkNumber(expr.operator, left, right)
             #subtract if given
             return float(left) - float(right)

--- a/PySkiylia/Interpreter.py
+++ b/PySkiylia/Interpreter.py
@@ -160,16 +160,38 @@ class Interpreter(misc, Evaluator):
             self.checkNumber(expr.operator, left, right)
             #greater comparison
             return float(left) > float(right)
+        if optype == "EGreater":
+            self.checkNumber(expr.operator, left, right)
+            #greater or equal comparison
+            return float(left) >= float(right)
         if optype == "Less":
             self.checkNumber(expr.operator, left, right)
-            #greater comparison
+            #less comparison
             return float(left) < float(right)
-        if optype == "NotEqual":
+        if optype == "ELess":
+            self.checkNumber(expr.operator, left, right)
+            #less of equal comparison
+            return float(left) <= float(right)
+        if optype == "NEqual":
             #inequality comparison
             return not self.isEqual(left, right)
-        if optype == "EqualEqual":
+        if optype == "EEqual":
             #equality comparison
             return self.isEqual(left, right)
+        if optype == "NEEqual":
+            #strictly not equal
+            if isinstance(left, type(right)) and self.isEqual(left, right):
+                #if they're the same type, and are equal, return false
+                return False
+            #true in any other case
+            return True
+        if optype == "EEEqual":
+            #strictly equal
+            if isinstance(left, type(right)):
+                #if they're the same type, check if they are equal
+                return self.isEqual(left, right)
+            #false if they have different types
+            return False
         if optype == "Minus":
             self.checkNumber(expr.operator, left, right)
             #subtract if given
@@ -180,7 +202,7 @@ class Interpreter(misc, Evaluator):
             if float(right) == 0:
                 raise RuntimeError([expr.operator,"division by zero"])
             return float(left) / float(right)
-        elif optype == "StarStar":
+        elif optype == "StStar":
             self.checkNumber(expr.operator, left, right)
             return float(left) ** float(right)
         elif optype == "Star":
@@ -436,7 +458,7 @@ class Interpreter(misc, Evaluator):
             #return the not of the operand
             return not self.isTruthy(right)
         #check if it is an incremental
-        elif optype == "PlusPlus":
+        elif optype == "PPlus":
             #ensure the operator is a number we can increment
             self.checkNumber(expr.operator, right)
             #fetch the value of the operand
@@ -456,7 +478,7 @@ class Interpreter(misc, Evaluator):
             #otherwise return the value + 1
             return value + 1
         #check if it is an decremental
-        elif optype == "MinusMinus":
+        elif optype == "MMinus":
             #ensure the operator is a number we can decrement
             self.checkNumber(expr.operator, right)
             #fetch the value of the operand

--- a/PySkiylia/Interpreter.py
+++ b/PySkiylia/Interpreter.py
@@ -183,24 +183,24 @@ class Interpreter(misc, Evaluator):
             return self.isEqual(left, right)
         elif optype == "NEEqual":
             #strictly not equal
-            if isinstance(left, type(right)) and self.isEqual(left, right):
+            if (isinstance(left, type(right)) or isinstance(right, type(left))) and self.isEqual(left, right):
                 #if they're the same type, and are equal, return false
                 return False
             #true in any other case
             return True
         elif optype == "EEEqual":
             #strictly equal
-            if isinstance(left, type(right)):
+            if (isinstance(left, type(right)) or isinstance(right, type(left))):
                 #if they're the same type, check if they are equal
                 return self.isEqual(left, right)
             #false if they have different types
             return False
         elif optype == "NFuzequal":
             #Fuzzily equal only checks for type equality
-            return not isinstance(left, type(right))
+            return not (isinstance(left, type(right)) or isinstance(right, type(left)))
         elif optype == "Fuzequal":
             #Fuzzily equal only checks for type equality
-            return isinstance(left, type(right))
+            return (isinstance(left, type(right)) or isinstance(right, type(left)))
         elif optype == "Minus":
             self.checkNumber(expr.operator, left, right)
             #subtract if given

--- a/PySkiylia/Interpreter.py
+++ b/PySkiylia/Interpreter.py
@@ -69,8 +69,12 @@ class misc:
         #if only one is null, return false
         if a==None:
             return False
-        #else return the python equality
-        return a==b
+        try:
+            b = type(a)(b)
+            return a==b
+        except:
+            #else return the python equality
+            return a==b
 
 #define the Interpreter class
 class Interpreter(misc, Evaluator):

--- a/PySkiylia/Lexer.py
+++ b/PySkiylia/Lexer.py
@@ -133,6 +133,8 @@ class Lexer:
                     return self.addToken("EEEqual")
                 return self.addToken("EEqual")
             return self.addToken("Equal")
+        elif c == "~" and self.match("~") and self.match("~"):
+            return self.addToken("Fuzequal")
         elif c == "?":
             if self.match(":"):
                 return self.addToken("QColon")
@@ -154,6 +156,8 @@ class Lexer:
                 if self.match("="):
                     return self.addToken("NEEqual")
                 return self.addToken("NEqual")
+            elif self.match("~") and self.match("~"):
+                return self.addToken("NFuzequal")
             return self.addToken("Not")
         elif c == "\t":
             #if we met an indentation, then increment our indent tage

--- a/PySkiylia/Lexer.py
+++ b/PySkiylia/Lexer.py
@@ -121,11 +121,11 @@ class Lexer:
                 return self.addToken("Slash")
         elif c == ">":
             if self.match("="):
-                return self.addToken("GEqual")
+                return self.addToken("EGreater")
             return self.addToken("Greater")
         elif c == "<":
             if self.match("="):
-                return self.addToken("LEqual")
+                return self.addToken("ELess")
             return self.addToken("Less")
         elif c == "=":
             if self.match("="):

--- a/PySkiylia/Lexer.py
+++ b/PySkiylia/Lexer.py
@@ -237,8 +237,9 @@ class Lexer:
             while self.isDigit(self.peek()):
                 #advance to the next character
                 self.advance()
-        #create a numeric token and return. all numbers are float natively I guess
-        return self.addToken("Number", float(self.source[self.start:self.current]))
+            return self.addToken("Float", float(self.source[self.start:self.current]))
+        #create a numeric token and return.
+        return self.addToken("Integer", int(self.source[self.start:self.current]))
 
     #define a way of checking if the value is a digit
     def isDigit(self, char):

--- a/PySkiylia/Lexer.py
+++ b/PySkiylia/Lexer.py
@@ -92,15 +92,15 @@ class Lexer:
             return self.addToken("Dot")
         elif c == "-":
             if self.match("-"):
-                return self.addToken("MinusMinus")
+                return self.addToken("MMinus")
             return self.addToken("Minus")
         elif c == "+":
             if self.match("+"):
-                return self.addToken("PlusPlus")
+                return self.addToken("PPlus")
             return self.addToken("Plus")
         elif c == "*":
             if self.match("*"):
-                return self.addToken("StarStar")
+                return self.addToken("StStar")
             return self.addToken("Star")
         elif c == "/":
             #as division and comments use the same character, check if the next is a comment
@@ -120,12 +120,18 @@ class Lexer:
             else:
                 return self.addToken("Slash")
         elif c == ">":
+            if self.match("="):
+                return self.addToken("GEqual")
             return self.addToken("Greater")
         elif c == "<":
+            if self.match("="):
+                return self.addToken("LEqual")
             return self.addToken("Less")
         elif c == "=":
             if self.match("="):
-                return self.addToken("EqualEqual")
+                if self.match("="):
+                    return self.addToken("EEEqual")
+                return self.addToken("EEqual")
             return self.addToken("Equal")
         elif c == "?":
             if self.match(":"):
@@ -145,7 +151,9 @@ class Lexer:
             return self.addToken("Or")
         elif c == "!":
             if self.match("="):
-                return self.addToken("NotEqual")
+                if self.match("="):
+                    return self.addToken("NEEqual")
+                return self.addToken("NEqual")
             return self.addToken("Not")
         elif c == "\t":
             #if we met an indentation, then increment our indent tage

--- a/PySkiylia/Parser.py
+++ b/PySkiylia/Parser.py
@@ -428,7 +428,7 @@ class Parser:
     #define the equality gramar
     def equality(self):
         #grab the binaary operation
-        return self.leftAssociative(self.comparison, "NEqual", "NEEqual", "EEqual", "EEEqual")
+        return self.leftAssociative(self.comparison, "NEqual", "NEEqual", "NFuzequal", "EEqual", "EEEqual", "Fuzequal")
 
     #define the comparison grammar
     def comparison(self):
@@ -584,7 +584,7 @@ class Parser:
     def checkError(self):
         a = "" #function to execute if we find an error
         #check if we have an equality
-        if self.match("NEqual", "NEEqual", "EEqual", "EEEqual"):
+        if self.match("NEqual", "NEEqual", "NFuzequal", "EEqual", "EEEqual", "Fuzequal"):
             a = self.equality
         #or a comparison
         elif self.match("Greater", "EGreater", "Less", "ELess"):

--- a/PySkiylia/Parser.py
+++ b/PySkiylia/Parser.py
@@ -587,7 +587,7 @@ class Parser:
         if self.match("NEqual", "NEEqual", "EEqual", "EEEqual"):
             a = self.equality
         #or a comparison
-    elif self.match("Greater", "EGreater", "Less", "ELess"):
+        elif self.match("Greater", "EGreater", "Less", "ELess"):
             a = self.comparison
         #or an addition (a blank '-' is a unary operator as well)
         elif self.match("Plus"):

--- a/PySkiylia/Parser.py
+++ b/PySkiylia/Parser.py
@@ -553,7 +553,7 @@ class Parser:
         elif self.match("Null"):
             return Literal(None)
         #check if a number or string
-        elif self.match("Number", "String"):
+        elif self.match("Float", "Integer", "String"):
             return Literal(self.previous().literal)
         #check if we have a "self"
         elif self.match("Self"):

--- a/PySkiylia/Parser.py
+++ b/PySkiylia/Parser.py
@@ -428,12 +428,12 @@ class Parser:
     #define the equality gramar
     def equality(self):
         #grab the binaary operation
-        return self.leftAssociative(self.comparison, "NotEqual", "EqualEqual")
+        return self.leftAssociative(self.comparison, "NEqual", "NEEqual", "EEqual", "EEEqual")
 
     #define the comparison grammar
     def comparison(self):
         #grab the binaary operation
-        return self.leftAssociative(self.term, "Greater", "Less")
+        return self.leftAssociative(self.term, "Greater", "EGreater", "Less", "ELess")
 
     #define the term grammar
     def term(self):
@@ -443,7 +443,7 @@ class Parser:
     #define the factor grammar
     def factor(self):
         #grab the binaary operation
-        return self.leftAssociative(self.unary, "Star", "Slash", "StarStar")
+        return self.leftAssociative(self.unary, "Star", "Slash", "StStar")
 
     #shorthand code for all left associative binary operations
     def leftAssociative(self, operand, *operators, ExprType=Binary):
@@ -471,7 +471,7 @@ class Parser:
             #return the unary combination
             return Unary(operator, right)
         #check for prefix '++' and '--'.
-        elif self.match("PlusPlus", "MinusMinus"):
+        elif self.match("PPlus", "MMinus"):
             #fetch the operator
             operator = self.previous()
             #fetch the call that may follow
@@ -484,7 +484,7 @@ class Parser:
     #define the postfix grammar
     def postfix(self):
         #this is right associative, so check first
-        if self.checkNext("PlusPlus", "MinusMinus"):
+        if self.checkNext("PPlus", "MMinus"):
             #fetch the call that comes before
             left = self.call()
             #fetch the operator
@@ -584,16 +584,16 @@ class Parser:
     def checkError(self):
         a = "" #function to execute if we find an error
         #check if we have an equality
-        if self.match("NotEqual", "Equal"):
+        if self.match("NEqual", "NEEqual", "EEqual", "EEEqual"):
             a = self.equality
         #or a comparison
-        elif self.match("Greater", "Less"):
+    elif self.match("Greater", "EGreater", "Less", "ELess"):
             a = self.comparison
         #or an addition (a blank '-' is a unary operator as well)
         elif self.match("Plus"):
             a = self.term
         #and finally a factor
-        elif self.match("Slash", "Star", "StarStar"):
+        elif self.match("Slash", "Star", "StStar"):
             a = self.factor
         #otherwise, return false, as we didn't encounter an erroneous left hand operation
         else:
@@ -606,7 +606,7 @@ class Parser:
         return True
 
     def constructincremental(self, var):
-        self.tokens.insert(self.current, Tokens.Token("PlusPlus", "++", None, var.line, var.char, var.indent))
+        self.tokens.insert(self.current, Tokens.Token("PPlus", "++", None, var.line, var.char, var.indent))
         self.tokens.insert(self.current, var)
 
     #define a way of checking if a token is found, and consuming it

--- a/PySkiylia/PySkiylia.py
+++ b/PySkiylia/PySkiylia.py
@@ -14,7 +14,7 @@ from ASTPrinter import ASTPrinter
 class Skiylia:
     #set the default values here
     haderror = False
-    version = "v0.6.4"
+    version = "v0.7.0"
     debug = False
     #run this at initialisation
     def __init__(self, args=""):

--- a/PySkiylia/Tokens.py
+++ b/PySkiylia/Tokens.py
@@ -4,10 +4,11 @@
 tokens = [#single character tokens
             "LeftParenthesis", "RightParenthesis", "Colon", "Comma", "Dot", "Slash", "And", "Or", "Xor",
             #single or double character Tokens
-            "NEEqual", "NEqual", "Not", "EEEqual", "EEqual", "Equal", "Greater", "EGreater", "Less", "ELess"
-            "Star", "StStar", "Minus", "MMinus", "Plus", "PPlus", "Question", "QColon", "QQuestion",
+            "NFuzequal", "NEEqual", "NEqual", "Not", "Fuzequal", "EEEqual", "EEqual", "Equal",
+            "Greater", "EGreater", "Less", "ELess", "Question", "QColon", "QQuestion",
+            "Star", "StStar", "Minus", "MMinus", "Plus", "PPlus",
             #Literal tokens
-            "String", "Number", "Identifier",
+            "String", "Integer", "Float", "Identifier",
             #keyword tokens
             "Class", "Def", "Do", "Elif", "Else", "False", "For", "If", "Null", "Return", "Self", "Super", "True", "Var", "Where", "While",
             #miscellaneous

--- a/PySkiylia/Tokens.py
+++ b/PySkiylia/Tokens.py
@@ -4,7 +4,7 @@
 tokens = [#single character tokens
             "LeftParenthesis", "RightParenthesis", "Colon", "Comma", "Dot", "Slash", "And", "Or", "Xor",
             #single or double character Tokens
-            "NEEqual", "NEqual", "Not", "EEEqual", "EEqual", "Equal", "Greater", "GEqual", "Less", "LEqual"
+            "NEEqual", "NEqual", "Not", "EEEqual", "EEqual", "Equal", "Greater", "EGreater", "Less", "ELess"
             "Star", "StStar", "Minus", "MMinus", "Plus", "PPlus", "Question", "QColon", "QQuestion",
             #Literal tokens
             "String", "Number", "Identifier",

--- a/PySkiylia/Tokens.py
+++ b/PySkiylia/Tokens.py
@@ -2,9 +2,10 @@
 """Stores token definitions, may end up moving this elsewhere"""
 
 tokens = [#single character tokens
-            "LeftParenthesis", "RightParenthesis", "Colon", "Comma", "Dot", "Slash", "Greater", "Less", "And", "Or", "Xor",
+            "LeftParenthesis", "RightParenthesis", "Colon", "Comma", "Dot", "Slash", "And", "Or", "Xor",
             #single or double character Tokens
-            "NotEqual", "Not", "EqualEqual", "Equal", "Star", "StarStar", "Minus", "MinusMinus", "Plus", "PlusPlus", "Question", "QColon", "QQuestion",
+            "NEEqual", "NEqual", "Not", "EEEqual", "EEqual", "Equal", "Greater", "GEqual", "Less", "LEqual"
+            "Star", "StStar", "Minus", "MMinus", "Plus", "PPlus", "Question", "QColon", "QQuestion",
             #Literal tokens
             "String", "Number", "Identifier",
             #keyword tokens


### PR DESCRIPTION
PySkiylia now has support for:
comparitive equality:
- Greater or equal: '<='
- Less or equal: '>='

strict equality:
- Strictly equal: '==='
- Strictly not equal: '!=='
(Strict equality requires both objects have the same type before evaluating their values)

Fuzzily equal:
- Fuzzily equal: '~~~'
- Fuzzily not equal '!~~'
(Fuzzy equality checks only the object type, and does not evaluate their values)